### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/1-kickoff-and-team-formation.md
+++ b/Instructions/Labs/1-kickoff-and-team-formation.md
@@ -1,6 +1,10 @@
 ---
-task:
-    title: 'WWL Frontier Hack Event – Kickoff & Team Formation'
+lab:
+  title: Untitled exercise
+  description: '**Suggested time:** 10 minutes'
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 ## Step 1: Kickoff & Team Formation

--- a/Instructions/Labs/2-define-the-challenge.md
+++ b/Instructions/Labs/2-define-the-challenge.md
@@ -1,6 +1,10 @@
 ---
-task:
-    title: 'WWL Frontier Hack Event – Define the Challenge'
+lab:
+  title: Untitled exercise
+  description: '**Suggested time:** 10 minutes'
+  duration: 10 minutes
+  level: 200
+  islab: true
 ---
 
 ## Step 2: Define the Challenge

--- a/Instructions/Labs/3-break-down-the-problem.md
+++ b/Instructions/Labs/3-break-down-the-problem.md
@@ -1,6 +1,10 @@
 ---
-task:
-    title: 'WWL Frontier Hack Event – Break Down the Problem'
+lab:
+  title: Untitled exercise
+  description: '**Suggested time:** 10 minutes'
+  duration: 10 minutes
+  level: 200
+  islab: true
 ---
 
 ## Step 3: Break Down the Problem  

--- a/Instructions/Labs/4-explore-ai-solutions.md
+++ b/Instructions/Labs/4-explore-ai-solutions.md
@@ -1,6 +1,10 @@
 ---
-task:
-    title: 'WWL Frontier Hack Event – Explore AI Solutions'
+lab:
+  title: Untitled exercise
+  description: '**Suggested time:** 20 minutes'
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 ## Step 4: Explore AI Solutions  

--- a/Instructions/Labs/5-make-the-case.md
+++ b/Instructions/Labs/5-make-the-case.md
@@ -1,6 +1,10 @@
 ---
-task:
-    title: 'WWL Frontier Hack Event – Make the Case'
+lab:
+  title: Untitled exercise
+  description: '**Suggested time:** 10 minutes'
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 ## Step 5: Make the Case

--- a/Instructions/Labs/6-submit-your-idea.md
+++ b/Instructions/Labs/6-submit-your-idea.md
@@ -1,6 +1,10 @@
 ---
-task:
-    title: 'WWL Frontier Hack Event – Submit Your Idea'
+lab:
+  title: Untitled exercise
+  description: '**Suggested time:** 10 minutes'
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 ## Step 6: Submit Your Idea


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/1-kickoff-and-team-formation.md` (normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/2-define-the-challenge.md` (normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/3-break-down-the-problem.md` (normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/4-explore-ai-solutions.md` (normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/5-make-the-case.md` (normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/6-submit-your-idea.md` (normalized_case_keys,title,description,duration,level,islab)
